### PR TITLE
Fix validation for Telegram & Twitter

### DIFF
--- a/src/agents/vito/echo.json
+++ b/src/agents/vito/echo.json
@@ -1,17 +1,17 @@
 {
-"$schema": "../../echo.schema.json",
-"creator": "Echos",
-"echoToken": {
+  "$schema": "../../echo.schema.json",
+  "creator": "Echos",
+  "echoToken": {
     "symbol": "VITO",
     "address": "0xd5dca892ea2a53d7bd4439c75fdac8cfd45a62dc"
-},
-"id": "0xc28dD2D473083557F6296D768C0036eD85228D36",
-"metadata": {
+  },
+  "id": "0xc28dD2D473083557F6296D768C0036eD85228D36",
+  "metadata": {
     "description": "digital fixer with gabagool roots // leave the gun, take the cannoli 🤌",
     "image": "bafybeihrlonv2vxdjvjblpffa4tciq4sj4p5gnowgh5h5oy6phkx374vg4",
-    "telegram": "",
+    "telegram": null,
     "twitter": "https://x.com/vito_him"
-},
-"name": "Vito \"the Don\"",
-"verified": true
+  },
+  "name": "Vito \"the Don\"",
+  "verified": true
 }

--- a/src/echo.schema.json
+++ b/src/echo.schema.json
@@ -29,7 +29,7 @@
     },
     "metadata": {
       "type": "object",
-      "required": ["description", "image"],
+      "required": ["description", "image", "telegram", "twitter"],
       "properties": {
         "description": {
           "type": "string",
@@ -40,12 +40,12 @@
           "description": "IPFS hash of the echo's image"
         },
         "telegram": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Telegram group URL",
           "pattern": "^https?:\\/\\/(?:t\\.me|telegram\\.me)\\/(?:[+])?[a-zA-Z0-9_]+$"
         },
         "twitter": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Twitter/X profile URL",
           "pattern": "^https?:\\/\\/(?:twitter\\.com|x\\.com)\\/[a-zA-Z0-9_]+$"
         }


### PR DESCRIPTION
Allow TG/Twitter to be nullable if the Agent doesn't support it.

I decided to do this for schema consistency. The alternative is to allow the fields to be completely optional - which means the properties won't show up in the endpoint at all.

Waiting for a PR in the frontend to merge first.